### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#博客
+# 博客
 线上地址:[http://beginman.sinaapp.com/](http://beginman.sinaapp.com/)
 
 一个django开发的博客.网址[http://beginman.sinaapp.com/](http://beginman.sinaapp.com/).  ||  [Github](https://github.com/BeginMan/newBlog)
 
 搭建在新浪SAE上，Clone一份改改setting里面就能运行本地，上传新浪sae上同步数据库里面就能在线展示。所有需要的第三方库都在site-packages文件夹中，可以将此内容copy到本地环境site-packages中，就可以用了。
 
-##开发环境
+## 开发环境
 Python 2.7
 
 Django 1.5.5
@@ -14,7 +14,7 @@ Mysql 5.5
 
 Boostrap
 
-##功能
+## 功能
 1.写博(基于Markdown编辑器)
 
 2.上传博客（将.md文件上传后自动生成博客，如限在github搭建博客将此同步到这里或本地撰写上传。）
@@ -27,10 +27,10 @@ Boostrap
 
 6.命令行发送博客 [地址Github](https://github.com/BeginMan/pytool/blob/master/spider/autoSendSaeBlog.py)
 
-##注意：
+## 注意：
 setting配置中，由于对七牛云存储进行封装，更改你的七牛云存储Key，name即可。
 
-##预览
+## 预览
 
 ![](http://images.cnblogs.com/cnblogs_com/BeginMan/486940/o_blog1.png)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
